### PR TITLE
Use fixtures to set path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,10 +9,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v1
-      - name: Run custom testing procedure
-        uses: matlab-actions/run-command@v1
-        with:
-          command: addpath(pwd); import h5tools.*;
       - name: Run tests and generate artifacts
         uses: matlab-actions/run-tests@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Run tests and generate artifacts
         uses: matlab-actions/run-tests@v1
         with:
-          # source-folder: +h5tools
+          source-folder: +h5tools
           select-by-folder: tests
           test-results-junit: test-results/results.xml
           code-coverage-cobertura: code-coverage/coverage.xml

--- a/tests/getSourceRoot.m
+++ b/tests/getSourceRoot.m
@@ -1,0 +1,3 @@
+function srcRoot = getSourceRoot
+srcRoot = fileparts(fileparts(mfilename("fullpath")));
+end

--- a/tests/test_copyGroup.m
+++ b/tests/test_copyGroup.m
@@ -4,7 +4,9 @@
 
 % Copyright (C) 2023- University College London (Bradley Treeby).
 
-classdef test_copyGroup < matlab.unittest.TestCase
+classdef (SharedTestFixtures = matlab.unittest.fixtures.PathFixture(getSourceRoot)) ...
+    test_copyGroup < matlab.unittest.TestCase
+    
     properties
         fromFile = 'testFrom.h5';
         toFile = 'testTo.h5';
@@ -59,4 +61,7 @@ classdef test_copyGroup < matlab.unittest.TestCase
         
     end
 
+end
+function srcRoot = getSourceRoot
+srcRoot = fileparts(fileparts(mfilename("fullpath")));
 end

--- a/tests/test_copyGroup.m
+++ b/tests/test_copyGroup.m
@@ -62,6 +62,3 @@ classdef (SharedTestFixtures = matlab.unittest.fixtures.PathFixture(getSourceRoo
     end
 
 end
-function srcRoot = getSourceRoot
-srcRoot = fileparts(fileparts(mfilename("fullpath")));
-end

--- a/tests/test_copyGroup.m
+++ b/tests/test_copyGroup.m
@@ -4,7 +4,7 @@
 
 % Copyright (C) 2023- University College London (Bradley Treeby).
 
-classdef (SharedTestFixtures = matlab.unittest.fixtures.PathFixture(getSourceRoot)) ...
+classdef (SharedTestFixtures = {matlab.unittest.fixtures.PathFixture(getSourceRoot)}) ...
     test_copyGroup < matlab.unittest.TestCase
     
     properties


### PR DESCRIPTION
Solves issue with CI paths, by using fixtures to define the root path to the toolbox.